### PR TITLE
Mirror of paypal paypal-java-sdk#328

### DIFF
--- a/rest-api-sdk/src/main/java/com/paypal/base/rest/APIContext.java
+++ b/rest-api-sdk/src/main/java/com/paypal/base/rest/APIContext.java
@@ -64,6 +64,7 @@ public class APIContext {
 	 */
 	public APIContext(String clientID, String clientSecret, String mode) {
 		this(clientID, clientSecret, mode, null);
+		addConfiguration(Constants.CLIENT_ID, clientID);
 	}
 
 	/**


### PR DESCRIPTION
Mirror of paypal paypal-java-sdk#328
https://github.com/paypal/PayPal-REST-API-issues/issues/178
  

* Environment: each and every environment
* Language, language version, and OS: MacOS, Oracle-Java 1.8.0-b132 (does not matter at all)


`
        <dependency>
            <groupId>com.paypal.sdk</groupId>
            <artifactId>rest-api-sdk</artifactId>
            <version>1.14.0</version>
        </dependency>
`

### Issue description

`
        com.paypal.base.rest.APIContext context = new com.paypal.base.rest.APIContext("myClientID", "myBla", "sandbox");
`

fails with missing client id credentials, i was able to workaround via:

`
        APIContext context = new APIContext("myClientID", "myBla", "sandbox");
        context.addConfiguration(com.paypal.base.Constants.CLIENT_ID, "myClientID");
`

I suppose, its a bug?
  
